### PR TITLE
Swift tools 4.x support (Swift PM 4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ Pods
 
 #Carthage
 Carthage/Build
+
+#SwiftPM
+.build

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,20 @@
+// swift-tools-version:4.0
 import PackageDescription
 
 let package = Package(
-    name: "SMLib")
+    name: "SMLib",
+    products: [
+        .library(
+            name: "SMLib",
+            targets: ["SMLib"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "SMLib",
+            dependencies: [],
+            path: ".",
+            sources: ["Source"]
+        ),
+    ]
+)


### PR DESCRIPTION
This will allow users using Xcode 11 to fetch SMLib using Swift-PM and use it in their projects, in lieu of cocoapods.